### PR TITLE
Reception Management 및 CustomMiddleware 구현

### DIFF
--- a/config/middlewares.py
+++ b/config/middlewares.py
@@ -1,0 +1,59 @@
+import jwt
+import json
+from django.utils.deprecation import MiddlewareMixin
+from channels.middleware import BaseMiddleware
+from django.http import JsonResponse
+
+
+class CustomHttpMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        token = request.headers.get("Authorization")
+        if not token:
+            return JsonResponse({"error": "Authentication token missing."}, status=401)
+
+        try:
+            payload = jwt.decode(token.split(" ")[1], options={"verify_signature": False})
+            request.user_id = payload.get("user_id")
+        except Exception as e:
+            return JsonResponse({"error": str(e)}, status=401)
+
+class CustomWsMiddleware(BaseMiddleware):
+    async def __call__(self, scope, receive, send):
+        print(f"CustomWsMiddleware received scope type: {scope['type']}")
+        token = get_jwt(scope['headers'])
+        if not token:
+            return await self.reject_request(send, "Authentication token missing.")
+        
+        try:
+            payload = jwt.decode(token, options={"verify_signature": False})
+            user_id = payload.get('user_id')
+            scope['user_id'] = user_id
+            
+        except Exception as e:
+            return await self.reject_request(send, str(e))
+        
+        scope['token'] = token
+        return await super().__call__(scope, receive, send)
+                    
+    async def reject_request(self, send, message, status=401):
+        headers = [(b"content-type", b"application/json")]
+        body = json.dumps({"error": message}).encode('utf-8')
+
+        await send({
+            "type": "http.response.start",
+            "status": status,
+            "headers": headers,
+        })
+        await send({
+            "type": "http.response.body",
+            "body": body,
+        })
+        
+def get_jwt(headers):
+    auth_header = dict(headers).get(b'authorization')
+    if auth_header:
+        auth_header = auth_header.decode()
+        prefix, token = auth_header.split(' ')
+        if prefix.lower() == 'bearer':
+            return token
+    return None

--- a/config/middlewares.py
+++ b/config/middlewares.py
@@ -19,7 +19,6 @@ class CustomHttpMiddleware(MiddlewareMixin):
 
 class CustomWsMiddleware(BaseMiddleware):
     async def __call__(self, scope, receive, send):
-        print(f"CustomWsMiddleware received scope type: {scope['type']}")
         token = get_jwt(scope['headers'])
         if not token:
             return await self.reject_request(send, "Authentication token missing.")

--- a/config/routing.py
+++ b/config/routing.py
@@ -1,11 +1,13 @@
 from channels.routing import ProtocolTypeRouter, URLRouter
-from channels.auth import AuthMiddlewareStack
+from django.core.asgi import get_asgi_application
 from game.routing import websocket_urlpatterns
+from config.middlewares import CustomWsMiddleware
+
+django_asgi_app = get_asgi_application()
 
 application = ProtocolTypeRouter({
-    "websocket": AuthMiddlewareStack(
-        URLRouter(
-            websocket_urlpatterns
-        )
+    "http": django_asgi_app,
+    "websocket": CustomWsMiddleware(
+        URLRouter(websocket_urlpatterns)
     ),
 })

--- a/config/services.py
+++ b/config/services.py
@@ -2,12 +2,12 @@ import aiohttp
 
 USER_SERVICE = "http://localhost:8000/api/user/"
 
-async def get_user(user_id, token):
+async def get_user(user_id):
     user_service_url = f'{USER_SERVICE}{user_id}/'
-    headers = {'Authorization': f'Bearer {token}'}
+    # headers = {'Authorization': f'Bearer {token}'}
     
     async with aiohttp.ClientSession() as session:
-        async with session.get(user_service_url, headers=headers, timeout=10) as response:
+        async with session.get(user_service_url, timeout=10) as response:
             if response.status == 200:
                 return await response.json()
             return None

--- a/config/services.py
+++ b/config/services.py
@@ -1,0 +1,13 @@
+import aiohttp
+
+USER_SERVICE = "http://localhost:8000/api/user/"
+
+async def get_user(user_id, token):
+    user_service_url = f'{USER_SERVICE}{user_id}/'
+    headers = {'Authorization': f'Bearer {token}'}
+    
+    async with aiohttp.ClientSession() as session:
+        async with session.get(user_service_url, headers=headers, timeout=10) as response:
+            if response.status == 200:
+                return await response.json()
+            return None

--- a/config/settings.py
+++ b/config/settings.py
@@ -26,7 +26,9 @@ INSTALLED_APPS = [
     'game',
 ]
 
+# 위에서부터 맞는 미들웨어 찾으므로 순서 중요
 MIDDLEWARE = [
+    'config.middlewares.CustomHttpMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/game/consumers.py
+++ b/game/consumers.py
@@ -1,14 +1,106 @@
 from channels.generic.websocket import AsyncWebsocketConsumer
 import json
+from .redis_utils import (
+    is_user_in_room,
+    add_user_to_room,
+    remove_user_from_room,
+    update_user_state,
+    should_start_game,
+    get_participants
+)
 
 
 class GameRoomConsumer(AsyncWebsocketConsumer):
     async def connect(self):
+        self.room_id = self.scope['url_route']['kwargs']['room_id']
+        self.room_group_name = f'gameroom_{self.room_id}'
+        self.user = self.scope['user']
+        self.user_id = self.user['id']
+        self.user_name = self.user['nickname']
+        
+        if await is_user_in_room(self.user_name):
+            await self.close(code=4000) # 4000(custom): 이미 소속된 방이 있음
+            return
+        
         await self.accept()
         
+        await self.channel_layer.group_add(
+            self.room_group_name,
+            self.channel_name
+        )
+        
+        await add_user_to_room(self.room_id, self.user_name)
+        
+        participants = await get_participants(self.room_id)
+        await self.send(text_data=json.dumps({
+            'type': 'participants',
+            'content': participants
+        }))
+        
+        await self.broadcast_message('join', {
+            'user_name': self.user_name
+        })
+        
     async def disconnect(self, close_code):
-        print("disconnect")
+        await remove_user_from_room(self.room_id, self.user_name)
+        
+        await self.broadcast_message('leave', {
+            'user_name': self.user_name
+        })
+        
+        await self.channel_layer.group_discard(
+            self.room_group_name,
+            self.channel_name
+        )
         
     async def receive(self, text_data):
         data = json.loads(text_data)
-        print(data)
+        message_type = data.get('type')
+        
+        if message_type == 'ready':
+            await self.handle_ready(data)
+            
+    async def handle_ready(self, data):
+        if 'is_ready' not in data:
+            await self.send(json.dumps({'error': 'is_ready field is required'}))
+            return
+        
+        is_ready = data['is_ready']
+        
+        await update_user_state(self.room_id, self.user_name, is_ready)
+        
+        await self.broadcast_message('ready', {
+            'user_name': self.user_name,
+            'is_ready': is_ready
+        })
+        
+        if await should_start_game(self.room_id):
+            await self.start_game()
+            
+    async def start_game(self):
+        # 로직 추가 예정
+        await self.broadcast_message('start', {
+            'message': 'Game start!'
+        })
+        
+    async def broadcast_message(self, message_type, content):
+        await self.channel_layer.group_send(
+            self.room_group_name,
+            {
+                'type': 'send_to_client',
+                'message_type': message_type,
+                'sender': self.channel_name,
+                'content': content
+            }
+        )
+
+    async def send_to_client(self, event):
+        if event.get('message_type') != 'start':
+            sender = event.get('sender')
+            if sender == self.channel_name:
+                return
+        
+        await self.send(text_data=json.dumps({
+            'type': event['message_type'],
+            'content': event['content']
+        }))

--- a/game/consumers.py
+++ b/game/consumers.py
@@ -9,8 +9,8 @@ from .redis_utils import (
     get_participants
 )
 from config.services import get_user
-from channels.db import database_sync_to_async
 from .models import Reception
+import asyncio
 
 
 class ReceptionConsumer(AsyncWebsocketConsumer):
@@ -22,7 +22,7 @@ class ReceptionConsumer(AsyncWebsocketConsumer):
         # token = self.scope['token']
         
         try:
-            self.reception = await database_sync_to_async(Reception.objects.get)(id=self.reception_id)
+            self.reception = await Reception.objects.aget(id=self.reception_id)
         except Reception.DoesNotExist:
             await self.close(code=4002)  # 4002: 해당 Reception이 없음 
             return
@@ -102,6 +102,7 @@ class ReceptionConsumer(AsyncWebsocketConsumer):
         await self.broadcast_message('start', {
             'message': 'Game start!'
         })
+        await asyncio.sleep(1)
         await self.close(code=5000) # 5000: 게임 시작
         
     async def broadcast_message(self, message_type, content):

--- a/game/migrations/0001_initial.py
+++ b/game/migrations/0001_initial.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name='GameRoom',
+            name='Reception',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=100)),

--- a/game/models.py
+++ b/game/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.contrib.auth.hashers import make_password, check_password
 
-class GameRoom(models.Model):
+class Reception(models.Model):
     name = models.CharField(max_length=100)
     password = models.CharField(max_length=255, null=True, blank=True)
     max_players = models.PositiveIntegerField(default=2)
@@ -20,4 +20,4 @@ class GameRoom(models.Model):
         return check_password(raw_password, self.password)
     
     def __str__(self):
-        return f"GameRoom: {self.name}"
+        return f"Reception: {self.name}"

--- a/game/redis_utils.py
+++ b/game/redis_utils.py
@@ -1,45 +1,45 @@
 import redis.asyncio as redis
 from .services import (
     get_participants_key,
-    get_user_room_key
+    get_user_reception_key
 )
 
 redis_client = redis.Redis(host='localhost', port=6379, db=0)
 
-async def is_user_in_room(user_name):
-    user_room_key = get_user_room_key(user_name)
-    existing_room = await redis_client.get(user_room_key)
-    if existing_room:
+async def is_user_in_reception(user_name):
+    user_reception_key = get_user_reception_key(user_name)
+    existing_reception = await redis_client.get(user_reception_key)
+    if existing_reception:
         return True
     return False
 
-async def add_user_to_room(room_id, user_name):
-    participants_key = get_participants_key(room_id)
+async def add_user_to_reception(reception_id, user_name):
+    participants_key = get_participants_key(reception_id)
     await redis_client.hset(participants_key, user_name, 0)
     
-    user_room_key = get_user_room_key(user_name)
-    await redis_client.set(user_room_key, room_id)
+    user_reception_key = get_user_reception_key(user_name)
+    await redis_client.set(user_reception_key, reception_id)
     
-async def remove_user_from_room(room_id, user_name):    
-    participants_key = get_participants_key(room_id)
+async def remove_user_from_reception(reception_id, user_name):    
+    participants_key = get_participants_key(reception_id)
     await redis_client.hdel(participants_key, user_name)
     
-    user_room_key = get_user_room_key(user_name)
-    await redis_client.delete(user_room_key)
+    user_reception_key = get_user_reception_key(user_name)
+    await redis_client.delete(user_reception_key)
     
-async def update_user_state(room_id, user_name, is_ready):
-    participants_key = get_participants_key(room_id)
+async def update_user_state(reception_id, user_name, is_ready):
+    participants_key = get_participants_key(reception_id)
     await redis_client.hset(participants_key, user_name, int(is_ready))
     
-async def should_start_game(room_id):
-    participants = await get_participants(room_id)
+async def should_start_game(reception_id):
+    participants = await get_participants(reception_id)
 
     if len(participants) > 1:
         return all(v == 1 for v in participants.values())
     return False
 
-async def get_participants(room_id):
-    participants_key = get_participants_key(room_id)
+async def get_participants(reception_id):
+    participants_key = get_participants_key(reception_id)
     participants = await redis_client.hgetall(participants_key)
     return {k.decode(): int(v.decode()) for k, v in participants.items()}
 

--- a/game/redis_utils.py
+++ b/game/redis_utils.py
@@ -31,6 +31,13 @@ async def update_user_state(reception_id, user_name, is_ready):
     participants_key = get_participants_key(reception_id)
     await redis_client.hset(participants_key, user_name, int(is_ready))
     
+async def should_remove_reception(reception_id):
+    participants = await get_participants(reception_id)
+    
+    if len(participants) < 1:
+        return True
+    return False
+    
 async def should_start_game(reception_id):
     participants = await get_participants(reception_id)
 

--- a/game/redis_utils.py
+++ b/game/redis_utils.py
@@ -1,0 +1,45 @@
+import redis.asyncio as redis
+from .services import (
+    get_participants_key,
+    get_user_room_key
+)
+
+redis_client = redis.Redis(host='localhost', port=6379, db=0)
+
+async def is_user_in_room(user_name):
+    user_room_key = get_user_room_key(user_name)
+    existing_room = await redis_client.get(user_room_key)
+    if existing_room:
+        return True
+    return False
+
+async def add_user_to_room(room_id, user_name):
+    participants_key = get_participants_key(room_id)
+    await redis_client.hset(participants_key, user_name, 0)
+    
+    user_room_key = get_user_room_key(user_name)
+    await redis_client.set(user_room_key, room_id)
+    
+async def remove_user_from_room(room_id, user_name):    
+    participants_key = get_participants_key(room_id)
+    await redis_client.hdel(participants_key, user_name)
+    
+    user_room_key = get_user_room_key(user_name)
+    await redis_client.delete(user_room_key)
+    
+async def update_user_state(room_id, user_name, is_ready):
+    participants_key = get_participants_key(room_id)
+    await redis_client.hset(participants_key, user_name, int(is_ready))
+    
+async def should_start_game(room_id):
+    participants = await get_participants(room_id)
+
+    if len(participants) > 1:
+        return all(v == 1 for v in participants.values())
+    return False
+
+async def get_participants(room_id):
+    participants_key = get_participants_key(room_id)
+    participants = await redis_client.hgetall(participants_key)
+    return {k.decode(): int(v.decode()) for k, v in participants.items()}
+

--- a/game/routing.py
+++ b/game/routing.py
@@ -1,6 +1,6 @@
 from django.urls import path
-from .consumers import GameRoomConsumer
+from .consumers import ReceptionConsumer
 
 websocket_urlpatterns = [
-    path("ws/gameRoom/<int:room_id>/", GameRoomConsumer.as_asgi()),
+    path("ws/reception/<int:reception_id>/", ReceptionConsumer.as_asgi()),
 ]

--- a/game/serializers.py
+++ b/game/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
-from .models import GameRoom
+from .models import Reception
 
-class GameRoomSerializer(serializers.ModelSerializer):
+class ReceptionSerializer(serializers.ModelSerializer):
     password = serializers.CharField(
         write_only=True,
         required=False,
@@ -11,7 +11,7 @@ class GameRoomSerializer(serializers.ModelSerializer):
     )
     
     class Meta:
-        model = GameRoom
+        model = Reception
         fields = ['id', 'name', 'password']
         extra_kwargs = {
             'name': {'required': True},
@@ -19,7 +19,7 @@ class GameRoomSerializer(serializers.ModelSerializer):
     
     def create(self, validated_data):
         password = validated_data.pop('password', None)
-        room = GameRoom(**validated_data)
-        room.set_password(password)
-        room.save()
-        return room
+        reception = Reception(**validated_data)
+        reception.set_password(password)
+        reception.save()
+        return reception

--- a/game/services.py
+++ b/game/services.py
@@ -1,0 +1,5 @@
+def get_participants_key(room_id):
+    return f'room_{room_id}_participants'
+
+def get_user_room_key(user_name):
+    return f'user_{user_name}_room'

--- a/game/services.py
+++ b/game/services.py
@@ -1,5 +1,5 @@
-def get_participants_key(room_id):
-    return f'room_{room_id}_participants'
+def get_participants_key(reception_id):
+    return f'reception_{reception_id}_participants'
 
-def get_user_room_key(user_name):
-    return f'user_{user_name}_room'
+def get_user_reception_key(user_name):
+    return f'user_{user_name}_reception'

--- a/game/tests.py
+++ b/game/tests.py
@@ -1,58 +1,58 @@
 from rest_framework.test import APITestCase, APIClient
 from django.urls import reverse
 from rest_framework import status
-from .models import GameRoom
+from .models import Reception
 
-class CreateGameRoomTestCase(APITestCase):
+class CreateReceptionTestCase(APITestCase):
     def setUp(self):
         self.client = APIClient()
-        self.url = reverse('create-room')
+        self.url = reverse('create-reception')
 
-    def test_create_room_without_password(self):
+    def test_create_reception_without_password(self):
         data = {
-            'name': 'Public Room'
+            'name': 'Public Reception'
         }
         response = self.client.post(self.url, data, format='json')
         
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data['name'], 'Public Room')
+        self.assertEqual(response.data['name'], 'Public Reception')
         self.assertIn('id', response.data)
         self.assertNotIn('password', response.data)
         
-        room = GameRoom.objects.get(id=response.data['id'])
-        self.assertIsNone(room.password)
+        reception = Reception.objects.get(id=response.data['id'])
+        self.assertIsNone(reception.password)
 
-    def test_create_room_with_password(self):
+    def test_create_reception_with_password(self):
         data = {
-            'name': 'Private Room',
+            'name': 'Private Reception',
             'password': 'securepassword123'
         }
         response = self.client.post(self.url, data, format='json')
         
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data['name'], 'Private Room')
+        self.assertEqual(response.data['name'], 'Private Reception')
         self.assertIn('id', response.data)
         self.assertNotIn('password', response.data)
         
-        room = GameRoom.objects.get(id=response.data['id'])
-        self.assertTrue(room.check_password('securepassword123'))
+        reception = Reception.objects.get(id=response.data['id'])
+        self.assertTrue(reception.check_password('securepassword123'))
 
-    def test_create_room_with_empty_password(self):
+    def test_create_reception_with_empty_password(self):
         data = {
-            'name': 'Empty Password Room',
+            'name': 'Empty Password reception',
             'password': ''
         }
         response = self.client.post(self.url, data, format='json')
         
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data['name'], 'Empty Password Room')
+        self.assertEqual(response.data['name'], 'Empty Password reception')
         self.assertIn('id', response.data)
         self.assertNotIn('password', response.data)
         
-        room = GameRoom.objects.get(id=response.data['id'])
-        self.assertTrue(room.check_password(''))
+        reception = Reception.objects.get(id=response.data['id'])
+        self.assertTrue(reception.check_password(''))
 
-    def test_create_room_without_name(self):
+    def test_create_reception_without_name(self):
         data = {}
         response = self.client.post(self.url, data, format='json')
         

--- a/game/tests.py
+++ b/game/tests.py
@@ -1,12 +1,22 @@
+# test_views.py
+
+import jwt
 from rest_framework.test import APITestCase, APIClient
 from django.urls import reverse
 from rest_framework import status
-from .models import Reception
+from game.models import Reception
 
 class CreateReceptionTestCase(APITestCase):
     def setUp(self):
         self.client = APIClient()
         self.url = reverse('create-reception')
+
+        # Generate a JWT token with a user_id
+        self.user_id = 1  # You can set this to any integer
+        self.token = jwt.encode({'user_id': self.user_id}, 'secret', algorithm='HS256')
+        
+        # Set the token in the client's headers
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.token)
 
     def test_create_reception_without_password(self):
         data = {
@@ -39,13 +49,13 @@ class CreateReceptionTestCase(APITestCase):
 
     def test_create_reception_with_empty_password(self):
         data = {
-            'name': 'Empty Password reception',
+            'name': 'Empty Password Reception',
             'password': ''
         }
         response = self.client.post(self.url, data, format='json')
         
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data['name'], 'Empty Password reception')
+        self.assertEqual(response.data['name'], 'Empty Password Reception')
         self.assertIn('id', response.data)
         self.assertNotIn('password', response.data)
         
@@ -59,3 +69,14 @@ class CreateReceptionTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('name', response.data)
         self.assertEqual(response.data['name'][0], 'This field is required.')
+
+    def test_create_reception_without_token(self):
+        # Remove the credentials
+        self.client.credentials()
+        data = {
+            'name': 'No Token Reception'
+        }
+        response = self.client.post(self.url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.json()['error'], 'Authentication token missing.')

--- a/game/urls.py
+++ b/game/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
-from .views import CreateGameRoomView
+from .views import CreateReceptionView
 
 urlpatterns = [
-    path('create-room/', CreateGameRoomView.as_view(), name='create-room'),
+    path('create-reception/', CreateReceptionView.as_view(), name='create-reception'),
 ]

--- a/game/views.py
+++ b/game/views.py
@@ -1,14 +1,14 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from .serializers import GameRoomSerializer
+from .serializers import ReceptionSerializer
 
-class CreateGameRoomView(APIView):
+class CreateReceptionView(APIView):
     def post(self, request):
-        serializer = GameRoomSerializer(data=request.data)
+        serializer = ReceptionSerializer(data=request.data)
         if serializer.is_valid():
-            room = serializer.save()
-            response_serializer = GameRoomSerializer(room)
+            reception = serializer.save()
+            response_serializer = ReceptionSerializer(reception)
             return Response(
                 response_serializer.data,
                 status=status.HTTP_201_CREATED

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+aiohappyeyeballs==2.4.4
+aiohttp==3.11.9
+aiosignal==1.3.1
 asgiref==3.8.1
 async-timeout==5.0.1
 attrs==24.2.0
@@ -11,13 +14,17 @@ cryptography==44.0.0
 daphne==4.1.2
 Django==5.1.3
 djangorestframework==3.15.2
+frozenlist==1.5.0
 hyperlink==21.0.0
 idna==3.10
 incremental==24.7.2
 msgpack==1.1.0
+multidict==6.1.0
+propcache==0.2.1
 pyasn1==0.6.1
 pyasn1_modules==0.4.1
 pycparser==2.22
+PyJWT==2.10.1
 pyOpenSSL==24.3.0
 redis==5.2.0
 service-identity==24.2.0
@@ -26,4 +33,5 @@ tomli==2.2.1
 Twisted==24.10.0
 txaio==23.1.1
 typing_extensions==4.12.2
+yarl==1.18.3
 zope.interface==7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,12 +14,14 @@ cryptography==44.0.0
 daphne==4.1.2
 Django==5.1.3
 djangorestframework==3.15.2
+exceptiongroup==1.2.2
 frozenlist==1.5.0
 hyperlink==21.0.0
 idna==3.10
 incremental==24.7.2
 msgpack==1.1.0
 multidict==6.1.0
+packaging==24.2
 propcache==0.2.1
 pyasn1==0.6.1
 pyasn1_modules==0.4.1


### PR DESCRIPTION
## 관련된 이슈 번호
- Closes #3 
- Closes #10 
- Closes #9 

# 주요 구현 사항
## Reception Managerment
Reception: 게임 대기 방이라는 뜻. (외국 살다온 연재님이 추천해준 이름)

### Join
- Reception에 웹소켓 연결 요청 시, `유효한 유저` + '유효한 방` + `이미 소속된 방`이 있는지 검증
- 연결 수락 시 해당 클라이언트에게 현재 방의 유저목록 전송
- 들어온 유저와 방 정보를 redis에서 관리
- 기존에 방에 있던 유저들에게 join 메시지 broadcast

### Disconnect
- redis에 추가된 사용자였으면 redis에서 삭제
- redis에서 삭제 후 방에 남아있는 인원이 1명 미만이면 방 삭제
- 웹 소켓 채널 그룹에서 제외

### Receive
- 받은 메시지 json 형태 검증

### Ready
- 'ready' 메시지를 받으면 해당 유저의 상태를 `is_ready`에 따라 update
- 방의 다른 유저들에게 broadcast
- 방 안의 모든 유저가 ready 상태면 1초 후 게임 시작(현재는 그냥 연결 종료)

## CustomMiddleware
jwt를 검증 없이 디코딩만 하여 사용하기 위해 `CustomMiddleware` 작성
- `HTTP`요청과 `WebSocket` 요청을 모두 처리하기 위해 각각 `CustomHttpMiddleware`, `CustomWsMiddleware` 작성
- 요청헤더에서 jwt 가져와서 디코딩 -> payload에서 `user_id` 가져와서 `scope['user_id]`에 설정

## User service와의 연동
`get_user(user_id)`: user_service로 `user_id`에 대한 정보 요청. 현재는 user 서비스에 jwt 인증 Middleware가 없어서 요청헤더에서 jwt 미포함

# 리뷰어 참고 사항

WebSocket Consumer 관련 test 코드를 작성하려는데 테스트 코드가 에러가 자꾸 나고 왜 안되겠는지 모르겠어서 
이틀동안 테스트 코드만 보다가 그냥 뺐습니다. 
테스트 코드는 없지만 postman으로 직접 방 생성 220개 해보면서 테스트 많이 돌려봤습니다. 

그리고 ReceptionManagement랑 CustomMiddleware랑 PR을 나누고 싶었는데
CustomMiddleware가 없으면 Reception이 동작이 안돼서
어쩔 수 없이 한 PR에 올립니다.

