### PR TITLE
Arena 종료에 대한 모든 것

### DIFF
--- a/config/consumer_utils.py
+++ b/config/consumer_utils.py
@@ -1,0 +1,11 @@
+from channels.layers import get_channel_layer
+
+async def broadcast_event(group_name, type, event=""):
+    channel_layer = get_channel_layer()
+    await channel_layer.group_send(
+        group_name,
+        {
+            'type': type,
+            'message': event
+        }
+    )

--- a/reception/services.py
+++ b/reception/services.py
@@ -11,7 +11,7 @@ from .redis_utils import (
     is_blacklisted,
     get_channel_name,
 )
-from config.services import get_user, get_invitation_group_name, get_user
+from config.services import get_user
 from channels.layers import get_channel_layer
 from .jwt_utils import verify_ws_token
 


### PR DESCRIPTION
## 주요 구현 사항

- 게임 종료 시 event 발생 시켜서 게임에 참가 중인 클라이언트들의 Consumer에서 처리하게 함: 
- 게임 도중에 나갈 경우, 게임 종료시키고 나간 사람 몰수패하게 함.
- 같은 플레이어가 들어왔다 나갔다 들어왔다 했을 때 플레이어 2명으로 인식되어 시작되던 문제 해결.