### PR TITLE
Tournament start API 구현

### DIFF
--- a/config/error_type.py
+++ b/config/error_type.py
@@ -19,6 +19,7 @@ class ErrorType(Enum):
     TOURNAMENT_NOT_FULL = (status.HTTP_403_FORBIDDEN, "Tournament is not full.")
     ALREADY_EXISTS = (status.HTTP_403_FORBIDDEN, "User already joined tournament.")
     TOURNAMENT_NOT_WAITING = (status.HTTP_403_FORBIDDEN, "Tournament is not in waiting state.")
+    PERPISSON_DENIED = (status.HTTP_403_FORBIDDEN, "You do not have permission to start this tournament.")
     
     USER_NOT_FOUND = (status.HTTP_404_NOT_FOUND, "User not found.")
     RECEPTION_NOT_FOUND = (status.HTTP_404_NOT_FOUND, "Reception not found.")

--- a/config/error_type.py
+++ b/config/error_type.py
@@ -19,7 +19,7 @@ class ErrorType(Enum):
     TOURNAMENT_NOT_FULL = (status.HTTP_403_FORBIDDEN, "Tournament is not full.")
     ALREADY_EXISTS = (status.HTTP_403_FORBIDDEN, "User already joined tournament.")
     TOURNAMENT_NOT_WAITING = (status.HTTP_403_FORBIDDEN, "Tournament is not in waiting state.")
-    PERPISSON_DENIED = (status.HTTP_403_FORBIDDEN, "You do not have permission to start this tournament.")
+    PERMISSION_DENIED = (status.HTTP_403_FORBIDDEN, "You do not have permission to start this tournament.")
     
     USER_NOT_FOUND = (status.HTTP_404_NOT_FOUND, "User not found.")
     RECEPTION_NOT_FOUND = (status.HTTP_404_NOT_FOUND, "Reception not found.")

--- a/config/services.py
+++ b/config/services.py
@@ -33,6 +33,8 @@ class UserService:
         channel_layer = get_channel_layer()
         channel_name = await get_channel_name(user_id)
         if not channel_name:
-            raise CustomValidationError(ErrorType.NOT_ONLINE)
+            # raise CustomValidationError(ErrorType.NOT_ONLINE)
+            return False
         
         await channel_layer.send(channel_name, message)
+        return True

--- a/tournament/models.py
+++ b/tournament/models.py
@@ -7,14 +7,19 @@ class Tournament(models.Model):
         IN_PROGRESS = 'in_progress', 'In Progress'
         FINISHED = 'finished', 'Finished'
         
-    VALID_PARTICIPANTS = [4,8,16]
+    # VALID_PARTICIPANTS = [4,8,16]
+    VALID_PARTICIPANTS = [1,2,4,8,16] # 개발용
 
     creator = models.IntegerField()
-    name = models.CharField(max_length=20)
+    name = models.CharField(max_length=40)
     max_participants = models.IntegerField(default=4)
     winner = models.IntegerField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     state = models.CharField(max_length=20, choices=State.choices, default=State.WAITING)
+    
+    @property
+    def current_participants(self):
+        return self.tournamentparticipant_set.count()
     
     @property
     def total_rounds(self):
@@ -23,6 +28,9 @@ class Tournament(models.Model):
     @classmethod
     def is_valid_participants(cls, value):
         return value in cls.VALID_PARTICIPANTS
+    
+    def is_full(self):
+        return self.current_participants == self.max_participants
     
     
 class TournamentParticipant(models.Model):

--- a/tournament/serializers.py
+++ b/tournament/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from .models import Tournament
 
 class TournamentSerializer(serializers.ModelSerializer):
-    current_participants = serializers.SerializerMethodField()
+    current_participants = serializers.ReadOnlyField()
     total_rounds = serializers.ReadOnlyField()
     
     class Meta:
@@ -20,9 +20,6 @@ class TournamentSerializer(serializers.ModelSerializer):
         extra_kwargs = {
             'creator': {'read_only': True},
         }
-        
-    def get_current_participants(self, obj):
-        return obj.tournamentparticipant_set.count()
     
     def validate_max_participants(self, value):
         if not Tournament.is_valid_participants(value):

--- a/tournament/services.py
+++ b/tournament/services.py
@@ -5,6 +5,7 @@ import asyncio
 from config.services import UserService
 from config.custom_validation_error import CustomValidationError
 from config.error_type import ErrorType
+from asgiref.sync import async_to_sync
 
 class TournamentService:
     @staticmethod
@@ -12,57 +13,47 @@ class TournamentService:
         return f"tournament_{tournament_id}"
     
     @staticmethod
-    async def get_current_participants(tournament_id: int):
-        return await TournamentParticipant.objects.filter(tournament_id=tournament_id).acount()
-    
-    @staticmethod
-    async def is_full(tournament: Tournament):
-        current_count = await TournamentParticipant.objects.filter(tournament=tournament).acount()
-        return current_count == tournament.max_participants
-
-    @staticmethod
-    async def join(tournament_id, user_id):
-        tournament = await Tournament.objects.aget(id=tournament_id)
+    def join(tournament_id, user_id):
+        tournament = Tournament.objects.get(id=tournament_id)
         
-        if await TournamentParticipant.objects.filter(tournament=tournament, user_id=user_id).aexists():
-            raise CustomValidationError(ErrorType.ALREADY_EXISTS)
-        if await TournamentService.is_full(tournament):
+        if tournament.state != tournament.State.WAITING:
+            raise CustomValidationError(ErrorType.TOURNAMENT_NOT_WAITING)
+        if tournament.is_full():
             raise CustomValidationError(ErrorType.TOURNAMENT_FULL)
-        if tournament.state != tournament.State.WAITING:
-            raise CustomValidationError(ErrorType.TOURNAMENT_NOT_WAITING)
+        if TournamentParticipant.objects.filter(tournament=tournament, user_id=user_id).exists():
+            raise CustomValidationError(ErrorType.ALREADY_EXISTS)
         
-        await TournamentParticipant.objects.acreate(tournament=tournament, user_id=user_id)
+        TournamentParticipant.objects.create(tournament=tournament, user_id=user_id)
 
     @staticmethod
-    async def start(tournament_id):
-        tournament = await Tournament.objects.aget(id=tournament_id)
+    def start(tournament_id, user_id):
+        tournament = Tournament.objects.get(id=tournament_id)
         
+        if tournament.creator != user_id:
+            raise CustomValidationError(ErrorType.PERPISSON_DENIED)
         if tournament.state != tournament.State.WAITING:
             raise CustomValidationError(ErrorType.TOURNAMENT_NOT_WAITING)
-        if not await TournamentService.is_full(tournament):
+        if not tournament.is_full():
             raise CustomValidationError(ErrorType.TOURNAMENT_NOT_FULL)
         
-        await TournamentService.set_players(tournament)
+        TournamentService.set_players(tournament)
+        tournament.state = Tournament.State.IN_PROGRESS
+        tournament.save()
         
-        user_ids = await TournamentService.get_participant_ids(tournament)
-        tasks = [
-            UserService.send_notification(user_id, {
+        user_ids = TournamentService.get_participant_ids(tournament)
+        for user_id in user_ids:
+            async_to_sync(UserService.send_notification)(user_id, {
                 "type":"tournament.start",
                 "url": TournamentService.get_grooup_name(tournament_id),
                 "message": f"The tournament \"{tournament.name}\" is starting!"
             })
-            for user_id in user_ids
-        ]
-        await asyncio.gather(*tasks)
         
     @staticmethod
-    async def update_bracket(tournament_id):
-        tournament = await Tournament.objects.aget(id=tournament_id)
-        all_matches = await Match.objects.filter(tournament=tournament).all()
+    def update_bracket(tournament_id):
+        tournament = Tournament.objects.get(id=tournament_id)
+        all_matches = Match.objects.filter(tournament=tournament).all()
         pending_matches = [match for match in all_matches if match.state == Match.State.PENDING]
         match_dict = {match.match_number: match for match in all_matches}
-        
-        tasks = []
         
         for match in pending_matches:
             match_number = match.match_number
@@ -81,40 +72,31 @@ class TournamentService:
                 
             if match.left_player and match.right_player:
                 match.state = Match.State.READY
-                tasks.append(match.asave())
-            
-        await asyncio.gather(*tasks)
+                match.save()
 
     @staticmethod
-    async def set_players(tournament:Tournament):
-        user_ids = await TournamentService.get_participant_ids(tournament)
-        matches:List[Match] = await TournamentService.create_matches(tournament)
+    def set_players(tournament:Tournament):
+        user_ids = TournamentService.get_participant_ids(tournament)
+        matches:List[Match] = TournamentService.create_matches(tournament)
         max_participants = tournament.max_participants
-        tasks = []
         
-        async def process_match(match_number: int):
+        for match_number in range(max_participants // 2, max_participants):
             match = matches[match_number - 1]
             i = match_number % max_participants // 2
             match.left_player = user_ids[i]
             match.right_player = user_ids[i + 1]
             match.state = match.State.READY
-            await match.asave()
-            
-        for match_number in range(max_participants // 2, max_participants):
-            tasks.append(process_match(match_number))
-            
-        await asyncio.gather(*tasks)
 
     @staticmethod    
-    async def create_matches(tournament: Tournament):
+    def create_matches(tournament: Tournament):
         matches = []
         for match_number in range(1, tournament.max_participants):
             round = tournament.total_rounds - int(math.log2(match_number))
-            match = await Match.objects.acreate(tournament=tournament, round=round, match_number=match_number)
+            match = Match.objects.create(tournament=tournament, round=round, match_number=match_number)
             matches.append(match)
             
         return matches
     
     @staticmethod
-    async def get_participant_ids(tournament: Tournament):
-        return await TournamentParticipant.objects.filter(tournament=tournament).values_list('user_id', flat=True)
+    def get_participant_ids(tournament: Tournament):
+        return TournamentParticipant.objects.filter(tournament=tournament).values_list('user_id', flat=True)

--- a/tournament/services.py
+++ b/tournament/services.py
@@ -30,7 +30,7 @@ class TournamentService:
         tournament = Tournament.objects.get(id=tournament_id)
         
         if tournament.creator != user_id:
-            raise CustomValidationError(ErrorType.PERPISSON_DENIED)
+            raise CustomValidationError(ErrorType.PERMISSION_DENIED)
         if tournament.state != tournament.State.WAITING:
             raise CustomValidationError(ErrorType.TOURNAMENT_NOT_WAITING)
         if not tournament.is_full():

--- a/tournament/services.py
+++ b/tournament/services.py
@@ -9,9 +9,9 @@ from asgiref.sync import async_to_sync
 
 class TournamentService:
     @staticmethod
-    def get_grooup_name(tournament_id):
-        return f"tournament_{tournament_id}"
-    
+    def get_websocket_url(tournament_id):
+        return f"ws/tournament/{tournament_id}/"
+
     @staticmethod
     def join(tournament_id, user_id):
         tournament = Tournament.objects.get(id=tournament_id)
@@ -43,7 +43,7 @@ class TournamentService:
         for user_id in user_ids:
             async_to_sync(UserService.send_notification)(user_id, {
                 "type":"tournament.start",
-                "url": TournamentService.get_grooup_name(tournament_id),
+                "url": TournamentService.get_websocket_url(tournament_id),
                 "message": f"The tournament \"{tournament.name}\" is starting!"
             })
             

--- a/tournament/urls.py
+++ b/tournament/urls.py
@@ -3,12 +3,12 @@ from .views import (
     TournamentCreateView,
     TournamentListView,
     TournamentJoinView,
-    # TournamentStartView
+    TournamentStartView
 )
 
 urlpatterns = [
     path('create/', TournamentCreateView.as_view(), name='create-tournament'),
     path('list/', TournamentListView.as_view(), name='tournaments'),
     path('<int:tournament_id>/join/', TournamentJoinView.as_view(), name='join-tournament'),
-    # path('start/', TournamentStartView.as_view(), name='start-tournament')
+    path('<int:tournament_id>/start/', TournamentStartView.as_view(), name='start-tournament')
 ]

--- a/tournament/views.py
+++ b/tournament/views.py
@@ -32,9 +32,16 @@ class TournamentJoinView(APIView):
     def post(self, request, tournament_id):
         user_id = request.user_id
         try:
-            async_to_sync(TournamentService.join)(tournament_id, user_id)
+            TournamentService.join(tournament_id, user_id)
         except CustomValidationError as e:
             return response_error(e)
         return response_ok()
 
-# class TournamentStartView(APIView):
+class TournamentStartView(APIView):
+    def post(self, request, tournament_id):
+        user_id = request.user_id
+        try:
+            TournamentService.start(tournament_id, user_id)
+        except CustomValidationError as e:
+            return response_error(e)
+        return response_ok()


### PR DESCRIPTION
## 주요 구현 사항

### TournamentService.start()
#### 검증
- 요청한 유저가 해당 토너먼트의 개최자인지 검증
- 해당 토너먼트가 WAITING 상태인지 검증
- 해당 토너먼트가 꽉 찬 상태인지 검증

#### set()
- create_matches(): round와 match_number를 부여해서 Match들 생성
- assign_players(): 매치에 참가 플레이어들 배치. 플레이어가 다 배치된 매치는 READY 상태로 변경
- Tournament의 상태를 IN_PROGRESS로 변경

#### send_notification()
- 토너먼트 참가자들의 개인 알림 채널로 `tournament.start` 이벤트 발행. 
- 이벤트에 `url`: 토너먼트 웹소켓 주소 포함