### PR TITLE
Participants 메시지 형식 수정 & toggle ready로 변경 & 자잘한 버그 수정

### DIFF
--- a/config/redis_services.py
+++ b/config/redis_services.py
@@ -1,4 +1,5 @@
 import redis.asyncio as redis
+import json
 
 redis_client = redis.Redis(host='localhost', port=6379, db=0)
 
@@ -22,14 +23,33 @@ class ReceptionRedisService:
     @staticmethod
     def get_playing_reception_key():
         return 'playing_reception'
+    
+    @staticmethod
+    def get_partial_detail(user_detail):
+        return {
+            "user_id": str(user_detail["id"]),
+            "nickname": user_detail["nickname"],
+            "avatar": user_detail["avatar"],
+            "is_ready": 0
+        }
 
     @staticmethod
-    async def add_user(reception_id, user_id):
+    async def add_user(reception_id, user_id, token):
         participants_key = ReceptionRedisService.get_participants_key(reception_id)
-        await redis_client.hset(participants_key, user_id, 0)
-        
         user_reception_key = ReceptionRedisService.get_user_reception_key(user_id)
+        
+        if await redis_client.hexists(participants_key, user_id):
+            return False
+        
+        user_detail = await UserRedisService.get_or_fetch_user(user_id, token)
+        if not user_detail:
+            return False
+        
+        partial_detail = ReceptionRedisService.get_partial_detail(user_detail)
+        
+        await redis_client.hset(participants_key, user_id, json.dumps(partial_detail))
         await redis_client.set(user_reception_key, reception_id)
+        return True
 
     @staticmethod    
     async def remove_user(reception_id, user_id):    
@@ -38,11 +58,17 @@ class ReceptionRedisService:
         
         user_reception_key = ReceptionRedisService.get_user_reception_key(user_id)
         await redis_client.delete(user_reception_key)
-
-    @staticmethod    
-    async def update_user_state(reception_id, user_id, is_ready):
+        
+    @staticmethod
+    async def toggle_ready(reception_id, user_id):
         participants_key = ReceptionRedisService.get_participants_key(reception_id)
-        await redis_client.hset(participants_key, user_id, int(is_ready))
+        raw_data = await redis_client.hget(participants_key, user_id)
+        if raw_data:
+            user_detail = json.loads(raw_data.decode())
+            current_ready_state = user_detail.get("is_ready", 0)
+            new_ready_state = 0 if current_ready_state == 1 else 1
+            user_detail["is_ready"] = new_ready_state
+            await redis_client.hset(participants_key, user_id, json.dumps(user_detail))
 
     @staticmethod    
     async def should_remove(reception_id):
@@ -57,14 +83,19 @@ class ReceptionRedisService:
         participants = await ReceptionRedisService.get_participants(reception_id)
 
         if len(participants) > 1:
-            return all(v == 1 for v in participants.values())
+            return all(p["is_ready"] == 1 for p in participants)
         return False
 
     @staticmethod
     async def get_participants(reception_id):
         participants_key = ReceptionRedisService.get_participants_key(reception_id)
-        participants = await redis_client.hgetall(participants_key)
-        return {k.decode(): int(v.decode()) for k, v in participants.items()}
+        raw_map = await redis_client.hgetall(participants_key)
+        
+        participants = []
+        for _, v in raw_map.items():
+            user_detail = json.loads(v.decode())
+            participants.append(user_detail)
+        return participants
 
     @staticmethod
     async def get_current_reception(user_id):
@@ -120,10 +151,39 @@ class UserRedisService:
     def get_channel_name_key():
         return 'user_channels'
     
+    @staticmethod
+    def get_user_detail_key(user_id):
+        return f"user:detail:{user_id}"
+    
     @staticmethod    
     async def get_channel_name(user_id):
         channel_name = await redis_client.hget(UserRedisService.get_channel_name_key(), user_id)
         return channel_name.decode() if channel_name else None
+    
+    @staticmethod
+    async def cache_user_detail(user_id, user_detail: dict, ttl=21600):
+        key = UserRedisService.get_user_detail_key(user_id)
+        await redis_client.set(key, json.dumps(user_detail), ex=ttl)
+    
+    @staticmethod
+    async def get_cached_user(user_id) -> dict:
+        key = UserRedisService.get_user_detail_key(user_id)
+        raw_data = await redis_client.get(key)
+        if raw_data:
+            return json.loads(raw_data)
+        return None
+    
+    @staticmethod
+    async def get_or_fetch_user(user_id, token):
+        cached = await UserRedisService.get_cached_user(user_id)
+        if cached:
+            return cached
+        
+        from config.services import UserService
+        user_detail = await UserService.get_user(user_id, token)
+        await UserRedisService.cache_user_detail(user_id, user_detail)
+        
+        return user_detail
 
 
 class ArenaRedisService:

--- a/config/settings.py
+++ b/config/settings.py
@@ -129,7 +129,7 @@ CHANNEL_LAYERS = {
 # PAGENATIOIN
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 10,  # 기본 페이지 크기 설정
+    'PAGE_SIZE': 5,  # 기본 페이지 크기 설정
 }
 
 # ENV


### PR DESCRIPTION
## 주요 구현 사항
프론트와 원만히 합의하여 수정했습니다.
- **reception_list 기본 페이지 크기 변경**: 
10 -> 5
- **participants 메시지 형식 변경**: 
기존 message의 형식을 dictionary에서 list로 변경.
is_ready도 같은 depth에 편입
- **participants 메시지 내용 변경**: 
avatar 정보 추가. 
아예 구조를 바꿔서 추후 다른 데이터도 딸깍으로 확장 가능
- **최적화**: 
기존 participans 호출할 때마다 유저 서비스로 요청 보냈었는데, 유저 정보를 redis에 caching하여 성능 최적화
- **ready 방식 변경**: 
기존 새로운 값으로 set 하던 방식에서 토글 방식으로 변경 -> 이제 그냥 `{'type': 'ready'}`만 보내도 알아서 토글로 동작

### 버그 수정
- `ARLEADY_ASSIGNED`: 
이미 소속되어 있는 reception에 대해서 join 요청 시에도 `ARLEADY_ASSIGNED`를 반환하던 버그 수정.
- **reception 웹소켓 중복 연결 버그**: 
같은 유저가 같은 reception에 대해 여러 웹소켓 연결을 맺을 때 발생하는 자잘한 버그들 수정. 
하지만 "처음 연결된 애가 대장이 돼서 얘가 먼저 나가면 남아있는 애들 이상해짐." 버그는 못 고침.

## 리뷰어 참고 사항

participants 응답 메시지 예시:
```json
{
    "type": "participants",
    "message": [
        {
            "user_id": "1",
            "nickname": "jooahn",
            "avatar": "대충url",
            "is_ready": 0
        },
        {
            "user_id": "2",
            "nickname": "jooahn2",
            "avatar": "대충url",
            "is_ready": 1
        }
    ]
}
```