### PR TITLE
Migrate server initiation to Daphne ASGI server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ RUN chmod +x /entrypoint.sh
 # 애플리케이션 코드 복사
 COPY ./config ./app
 
-# Django 서버 실행
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+# Start ASGI server with daphne
+CMD ["daphne", "-b", "0.0.0.0", "-p", "8000", "config.asgi:application"]


### PR DESCRIPTION
## 개요
Daphne ASGI 서버를 사용하여 서버 시작 방식을 개선하였습니다. 이를 통해 비동기 프레임워크와의 호환성을 강화하고, 프로덕션 환경에서 보다 적합한 배포를 지원합니다.

## 주요 변경사항
- **Dockerfile 업데이트**: 서버 시작 명령어를 Daphne ASGI 기반으로 변경
- **서버 시작 명령어 교체**:
  - 기존: `python manage.py runserver`
  - 변경: `daphne -b 0.0.0.0 -p 8000 config.asgi:application`
- **비동기 프레임워크 지원 강화**:
  - Django Channels 등 비동기 작업을 지원하기 위한 기반 제공
  - 생산성 및 확장성을 고려한 개선

## 개선 효과
1. **비동기 지원**:
   - Django Channels와 같은 비동기 프레임워크와의 호환성 강화
   - 웹소켓 및 실시간 데이터 처리 작업 최적화
2. **프로덕션 환경 적합성**:
   - 개발 환경뿐 아니라 프로덕션에서도 안정적으로 동작
   - `gunicorn` 대신 `daphne`를 사용하여 비동기 작업에 적합한 배포 가능

## 테스트 계획
1. Daphne 기반 서버에서 기존 기능의 정상 동작 확인
2. 비동기 작업(ex. 웹소켓)의 성능 테스트 수행
3. Docker 환경에서 배포 테스트 및 호환성 검증

## 리뷰어 참고 사항
이 변경사항은 비동기 기반 작업을 고려한 첫 단계로, 추후 Django Channels 도입 및 고도화 작업과 함께 사용될 수 있습니다.