### PR TITLE
Allowed hosts & install psycopg

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -5,8 +5,6 @@ from decouple import config # ENV
 SECRET_KEY = config("SECRET_KEY")
 DEBUG = config("DEBUG", default=False, cast=bool)
 
-WS_SECRET_KEY = config("WS_SECRET_KEY")
-WS_ALGORITHM = config("WS_ALGORITHM")
 USER_SERVICE_URL = config("USER_SERVICE_URL")
 
 DATABASE_ENGINE = config('DATABASE_ENGINE', default='sqlite3')

--- a/config/settings.py
+++ b/config/settings.py
@@ -17,7 +17,7 @@ REDIS_CAPACITY = config('REDIS_CAPACITY', cast=int)
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-ALLOWED_HOSTS = ['api-gateway', 'localhost']
+# ALLOWED_HOSTS = ['api-gateway', 'localhost']
 
 
 # Application definition

--- a/config/settings.py
+++ b/config/settings.py
@@ -19,7 +19,7 @@ REDIS_CAPACITY = config('REDIS_CAPACITY', cast=int)
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['api-gateway', 'localhost']
 
 
 # Application definition

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ multidict==6.1.0
 packaging==24.2
 pluggy==1.5.0
 propcache==0.2.1
+psycopg==3.2.3
 pyasn1==0.6.1
 pyasn1_modules==0.4.1
 pycparser==2.22


### PR DESCRIPTION
## 주요 구현 사항
- 전체 연결 중 필요한 패키지 설치
- allowed hosts 설정: api-gateway와 localhost의 요청만 허용하게