### PR TITLE
Arena에서 공의 충돌 계산 다듬기

### DIFF
--- a/arena/domain/ball.py
+++ b/arena/domain/ball.py
@@ -35,12 +35,17 @@ class Ball:
             self.velocity["x"] *= -1
             
     def _check_bar_collision(self, bar: "Bar") -> bool:
+        bar_collosion_bounds = bar.get_collision_bounds()
+        bar_x1 = bar_collosion_bounds["x1"]
+        bar_x2 = bar_collosion_bounds["x2"]
+        bar_y1 = bar_collosion_bounds["y1"]
+        bar_y2 = bar_collosion_bounds["y2"]
         return (
-            bar.x <= self.x + self.radius <= bar.x + bar.width and
-            bar.y <= self.y <= bar.y + bar.length
+            bar_x1 <= self.x + self.radius and
+            bar_y1 <= self.y <= bar_y2
         ) or (
-            bar.x <= self.x - self.radius <= bar.x + bar.width and
-            bar.y <= self.y <= bar.y + bar.length
+            self.x - self.radius <= bar_x2 and
+            bar_y1 <= self.y <= bar_y2
         )
 
     def check_boundary_collision(self):

--- a/arena/domain/bar.py
+++ b/arena/domain/bar.py
@@ -6,8 +6,10 @@ class Bar:
     def __init__(self, arena:"Arena", team:BaseMatch.Team):
         self.arena = arena
         self.team = team
-        self.length = 6
-        self.width = 1
+        self.width = 2
+        self.height = 10
+        self.x_radius = self.width / 2
+        self.y_radius = self.height / 2
         self.speed = 1
         self.x = 0
         self.y = 0
@@ -16,13 +18,21 @@ class Bar:
         
     def move(self, direction: Direction):
         if direction == Direction.UP:
-            self.y = max(self.y - self.speed, 0)
+            self.y = max(self.y - self.speed, 0 + self.y_radius)
         elif direction == Direction.DOWN:
-            self.y = min(self.y + self.speed, self.arena.height - self.length)
+            self.y = min(self.y + self.speed, self.arena.height - self.y_radius)
 
     def reset(self):
-        self.y = (self.arena.height - self.length) // 2
+        self.y = (self.arena.height - self.height) // 2
         if self.team == BaseMatch.Team.LEFT:
-            self.x = 0 + self.margin
+            self.x = 0 + self.x_radius + self.margin
         elif self.team == BaseMatch.Team.RIGHT:
-            self.x = self.arena.width - self.width - self.margin
+            self.x = self.arena.width - self.x_radius - self.margin
+            
+    def get_collision_bounds(self):
+        return {
+            "x1": self.x - self.x_radius,
+            "x2": self.x + self.x_radius,
+            "y1": self.y - self.y_radius,
+            "y2": self.y + self.y_radius,
+        }


### PR DESCRIPTION
## 주요 구현 사항

- 공과 탁구채의 충돌범위 계산 다듬기

## 리뷰어 참고 사항

- 현재 좌상(0,0) -> 우하(n,n) 좌표계
- 공(ball)과 탁구채(bar)의 (x, y) 좌표는 각 물체의 중심 좌표. 
- 충돌범위(렌더링 범위)는 중심좌표에서 (x_radius, y_radius)만큼씩 상하좌우로 충돌범위를 가짐
- ex) 공이 (x:10, y:10, radius:1) 이면 충돌 범위는 (9~11, 9~11) 임 