### PR TITLE
API 경로 수정

### DIFF
--- a/arena/routing.py
+++ b/arena/routing.py
@@ -2,6 +2,6 @@ from django.urls import path
 from .consumers import ArenaConsumer
 
 websocket_urlpatterns = [
-    path("ws/arena/<int:arena_id>/", ArenaConsumer.as_asgi(), name="websocket_arena"),
-    path("ws/tournament/<int:tournament_id>/match/<int:match_number>/", ArenaConsumer.as_asgi(), name="websocket_tournament_match"),
+    path("ws/game/arena/<int:arena_id>/", ArenaConsumer.as_asgi(), name="websocket_arena"),
+    path("ws/game/tournament/<int:tournament_id>/match/<int:match_number>/", ArenaConsumer.as_asgi(), name="websocket_tournament_match"),
 ]

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, include
 
 urlpatterns = [
-    path('api/reception/', include('reception.urls')),
-    path('api/tournament/', include('tournament.urls')),
-    path('api/arena/', include('arena.urls')),
+    path('api/game/reception/', include('reception.urls')),
+    path('api/game/tournament/', include('tournament.urls')),
+    path('api/game/arena/', include('arena.urls')),
 ]

--- a/reception/routing.py
+++ b/reception/routing.py
@@ -2,5 +2,5 @@ from django.urls import path
 from .consumers import ReceptionConsumer
 
 websocket_urlpatterns = [
-    path("ws/reception/<int:reception_id>/", ReceptionConsumer.as_asgi(), name="websocket_reception"),
+    path("ws/game/reception/<int:reception_id>/", ReceptionConsumer.as_asgi(), name="websocket_reception"),
 ]


### PR DESCRIPTION
## 주요 구현 사항

- 서비스의 이름을 prefix로 가지게 변경
- 기존: `api/reception/` -> 변경: `api/game/reception/`
