### PR TITLE
Reception에서 Arena로 이동 시 발견된 에러 해결

### DIFF
--- a/arena/consumers.py
+++ b/arena/consumers.py
@@ -25,7 +25,7 @@ class ArenaConsumer(AsyncWebsocketConsumer):
         await self.accept()
         await self.channel_layer.group_add(self.arena_group_name, self.channel_name)
         
-        self.initialize_arena()
+        await self.initialize_arena()
         
     async def initialize_data(self):
         kwargs = self.scope["url_route"]["kwargs"]

--- a/arena/domain/arena.py
+++ b/arena/domain/arena.py
@@ -15,7 +15,6 @@ class Arena:
         self.height = 76
         self.left_player = None
         self.right_player = None
-        self.ball = Ball(self)
         self.current_round = 1
         self.max_score = 2
         self._loop_task = None
@@ -23,6 +22,7 @@ class Arena:
         self.speed = 5
         self.group_name = None
         self.broadcast_func = None
+        self.ball = Ball(self)
     
     def set_messenger(self, group_name, broadcast_func):
         if self.group_name is None:
@@ -112,9 +112,21 @@ class Arena:
         
     def get_state(self):
         return {
-            "ball": {"x": self.ball.x, "y": self.ball.y},
-            "left_player_bar": self.left_player.bar.y,
-            "right_player_bar": self.right_player.bar.y,
+            "ball": 
+            {
+                "x": self.ball.x, 
+                "y": self.ball.y
+            },
+            "left_player_bar": 
+            {
+                "x": self.left_player.bar.x, 
+                "y": self.left_player.bar.y
+            },
+            "right_player_bar": 
+            {
+                "x": self.right_player.bar.x,
+                "y": self.right_player.bar.y
+            },
         }
     
     async def forfeit(self, exit_user_id):

--- a/arena/domain/ball.py
+++ b/arena/domain/ball.py
@@ -9,9 +9,9 @@ from arena.models import BaseMatch
 class Ball:
     def __init__(self, arena: "Arena"):
         self.arena = arena
-        self.reset()
         self.speed = 3
         self.radius = 1
+        self.reset()
         
     def update_position(self):
         self.x += self.velocity["x"]
@@ -27,11 +27,12 @@ class Ball:
         if self.y - self.radius <= 0 or self.y + self.radius >= self.arena.height:
             self.velocity["y"] *= -1  # 위/아래 벽 충돌
 
-        if self._check_bar_collision(lbar) or self._check_bar_collision(rbar):
+        if self.check_bar_collision(lbar) or self.check_bar_collision(rbar):
             self.velocity["x"] *= -1
             
-    def _check_bar_collision(self, bar: "Bar") -> bool:
+    def check_bar_collision(self, bar: "Bar") -> bool:
         bounds = bar.get_collision_bounds()
+        
         return (
             bounds["y1"] <= self.y <= bounds["y2"] and
             (

--- a/arena/domain/bar.py
+++ b/arena/domain/bar.py
@@ -24,9 +24,9 @@ class Bar:
         self.y = self.arena.height // 2
         if self.team == BaseMatch.Team.LEFT:
             self.x = 0 + self.x_radius + self.margin
-        elif self.team == BaseMatch.Team.RIGHT:
-            self.x = self.arena.width - self.x_radius - self.margin
-            
+        else:
+            self.x = self.arena.width - self.x_radius - self.margin    
+    
     def get_collision_bounds(self):
         return {
             "x1": self.x - self.x_radius,

--- a/arena/domain/player.py
+++ b/arena/domain/player.py
@@ -9,7 +9,7 @@ class Player:
     def __init__(self, user_id, arena: "Arena", team:BaseMatch.Team):
         self.team:BaseMatch.Team = team
         self.score = 0
-        self.bar:Bar = Bar(arena, None)
+        self.bar:Bar = Bar(arena, team)
         self.user_id = user_id
         
     def increment_score(self):

--- a/arena/routing.py
+++ b/arena/routing.py
@@ -2,6 +2,6 @@ from django.urls import path
 from .consumers import ArenaConsumer
 
 websocket_urlpatterns = [
-    path("ws/game/arena/<int:arena_id>/", ArenaConsumer.as_asgi(), name="websocket_arena"),
+    path("ws/game/arena/<str:arena_id>/", ArenaConsumer.as_asgi(), name="websocket_arena"),
     path("ws/game/tournament/<int:tournament_id>/match/<int:match_number>/", ArenaConsumer.as_asgi(), name="websocket_tournament_match"),
 ]


### PR DESCRIPTION
# 개요
- `reception`에서 `arena` 입장 시 "`Waiting for other player.`" 메시지가 동작하지 않았고, 이에 따라 Game 서비스의 Arena 초기화 및 상태 전송 로직 전반에 걸쳐 에러를 수정하였습니다.

## 주요 구현 사항
- `initialize_arena()` 함수가 `비동기` 함수였음에도 `await` 없이 호출되던 문제 수정
- `Ball`과 `Bar`의 `reset()` 호출 위치 재조정
  - `Arena`에서 `Ball`을 생성한 직후 **바로** `reset`하도록 위치 이동
  - `Bar`의 `reset` 로직에서 `elif → else`로 변경하여 팀 분기처리 누락 방지
  - `Player` 인스턴스의 Bar가 team 없이 초기화되던 문제 해결 (`Bar(arena, team)`으로 수정)
- `Arena`의 고유 ID가 URL에 <int:arena_id>로 정의되어 있었으나 실제 사용은 문자열 기반이므로 `<str:arena_id>`로 수정
- `get_state()` 함수에서 `bar` 정보를 단순 y좌표 → `{x, y}` 객체로 확장하여 정확한 위치 상태 전달