### PR TITLE
서비스별 데이터베이스 환경 변수 적용

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -83,9 +83,9 @@ elif DATABASE_ENGINE == 'postgresql':
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
-            'NAME': config('POSTGRES_DB', default=''),
-            'USER': config('POSTGRES_USER', default=''),
-            'PASSWORD': config('POSTGRES_PASSWORD', default=''),
+            'NAME': config('DB_GAME_NAME', default=''),
+            'USER': config('DB_GAME_USER', default=''),
+            'PASSWORD': config('DB_GAME_PASSWORD', default=''),
             'HOST': config('POSTGRES_HOST', default='localhost'),
             'PORT': config('POSTGRES_PORT', default='5432'),
         }


### PR DESCRIPTION
## 📌 변경 내용 요약
- 기존에 공통으로 사용하던 환경 변수(`POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`)를  
  각 서비스 전용 환경 변수(`DB_GAME_NAME`, `DB_GAME_USER`, `DB_GAME_PASSWORD`)로 분리했습니다.
- 이제 **Game 서비스는 전용 데이터베이스(game_db)** 에만 연결되며,  
  모든 서비스가 같은 DB(`mydatabase`)를 공유하던 문제를 해결했습니다.
- 이 변경은 **마이크로서비스 간 데이터베이스 격리 개선 작업**의 일부입니다.

## 🔗 관련 이슈
- Closes #57

## 💡 주요 변경 사항
- `config/settings.py`에서 서비스별 DB 환경 변수로 변경
  - `POSTGRES_DB` → `DB_GAME_NAME`
  - `POSTGRES_USER` → `DB_GAME_USER`
  - `POSTGRES_PASSWORD` → `DB_GAME_PASSWORD`
- 서비스 간 데이터베이스 충돌 방지
- 마이크로서비스 아키텍처 내 데이터 독립성 확보

## 🧩 리뷰어 참고 사항
- `.env` 파일의 값이 변경되었으므로, 로컬 환경에서 테스트 시 `.env`를 새로 적용해야 합니다.
- 기존 데이터(`mydatabase`)는 더 이상 사용하지 않으며, `game_db` 데이터베이스가 생성됩니다.
- **데이터베이스 및 사용자 생성 필요**:
  ```bash
  docker exec database_game psql -U myuser -d postgres -c "CREATE DATABASE game_db OWNER myuser;"
  docker exec database_game psql -U myuser -d postgres -c "CREATE USER game_user WITH PASSWORD 'game_pass';"
  docker exec database_game psql -U myuser -d game_db -c "GRANT ALL ON SCHEMA public TO game_user;"
  ```
- 관련 마이그레이션 명령어:
  ```bash
  docker exec game python manage.py migrate
  ```

## ✅ 테스트 방법
1. Game 서비스가 올바른 데이터베이스에 연결되는지 확인:
   ```bash
   docker exec game python manage.py shell -c "from django.conf import settings; print(settings.DATABASES['default']['NAME'])"
   # 예상 출력: game_db
   ```

2. 게임 관련 API 테스트 (예시):
   ```bash
   # 토너먼트 목록 조회 등
   curl http://localhost/api/game/tournaments/
   ```

